### PR TITLE
chore: add aloha browser to browser list

### DIFF
--- a/pass/autofill/impl/src/main/kotlin/proton/android/pass/autofill/BrowserList.kt
+++ b/pass/autofill/impl/src/main/kotlin/proton/android/pass/autofill/BrowserList.kt
@@ -5,6 +5,8 @@ val BROWSERS = setOf(
     "alook.browser.google",
     "app.vanadium.browser",
     "app.vanadium.webview",
+    "com.aloha.browser",
+    "com.alohamobile.browser",
     "com.amazon.cloud9",
     "com.android.browser",
     "com.android.chrome",

--- a/pass/autofill/impl/src/main/res/xml/autofill_service.xml
+++ b/pass/autofill/impl/src/main/res/xml/autofill_service.xml
@@ -9,6 +9,8 @@
     <compatibility-package android:name="alook.browser.google" android:maxLongVersionCode="10000000000" />
     <compatibility-package android:name="app.vanadium.browser" android:maxLongVersionCode="10000000000" />
     <compatibility-package android:name="app.vanadium.webview" android:maxLongVersionCode="10000000000" />
+    <compatibility-package android:name="com.aloha.browser" android:maxLongVersionCode="10000000000" />
+    <compatibility-package android:name="com.alohamobile.browser" android:maxLongVersionCode="10000000000" />
     <compatibility-package android:name="com.amazon.cloud9" android:maxLongVersionCode="10000000000" />
     <compatibility-package android:name="com.android.browser" android:maxLongVersionCode="10000000000" />
     <compatibility-package android:name="com.android.chrome" android:maxLongVersionCode="10000000000" />

--- a/tools/public/autofill/browsers.csv
+++ b/tools/public/autofill/browsers.csv
@@ -2,6 +2,8 @@ alook.browser,10000000000
 alook.browser.google,10000000000
 app.vanadium.browser,10000000000
 app.vanadium.webview,10000000000
+com.aloha.browser,10000000000
+com.alohamobile.browser,10000000000
 com.amazon.cloud9,10000000000
 com.android.browser,10000000000
 com.android.chrome,10000000000


### PR DESCRIPTION
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other

## Content
Add [Aloha Browser](https://play.google.com/store/apps/details?id=com.aloha.browser) and [Aloha Browser (Beta)](https://play.google.com/store/apps/details?id=com.alohamobile.browser) to browser list.
<!-- Describe shortly what has been changed -->

## Motivation and context

We, the engineering team at Aloha Browser, received a request from a user to add Aloha to the Proton Pass browser list to bypass the autocomplete dialog that appears every time our users fill out forms.

I used a [similar request](https://github.com/protonpass/android-pass/commit/3d61cc00c42a39b2d4853d60d562d107440b4a35) as a reference for this change.
